### PR TITLE
Configure Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+default.profraw

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+# TODO(allevato): Add Linux once we have the renaming issues sorted out.
+matrix:
+  include:
+    - os: osx
+      language: swift
+      osx_image: xcode9.1
+
+script:
+  - swift build
+  - swift test

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,20 @@
+// Generated using Sourcery 0.9.0 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import XCTest
+@testable import ICUTests
+
+extension SearchCursorTests {
+  static var allTests = [
+    ("testFirst", testFirst),
+    ("testNext", testNext),
+    ("testLast", testLast),
+    ("testPrevious", testPrevious),
+    ("testMoveToIndexFollowing", testMoveToIndexFollowing),
+    ("testMoveToIndexPreceding", testMoveToIndexPreceding),
+  ]
+}
+
+XCTMain([
+  testCase(SearchCursorTests.allTests),
+])

--- a/scripts/LinuxMain.stencil
+++ b/scripts/LinuxMain.stencil
@@ -1,0 +1,16 @@
+// sourcery:file:Tests/LinuxMain.swift
+import XCTest
+{{ argument.testimports }}
+
+{% for type in types.classes|based:"XCTestCase" %}
+{% if not type.annotations.disableTests %}extension {{ type.name }} {
+  static var allTests = [
+  {% for method in type.methods %}{% if method.parameters.count == 0 and method.shortName|hasPrefix:"test" %}  ("{{ method.shortName }}", {{ method.shortName }}),
+  {% endif %}{% endfor %}]
+}
+
+{% endif %}{% endfor %}
+XCTMain([
+{% for type in types.classes|based:"XCTestCase" %}{% if not type.annotations.disableTests %}  testCase({{ type.name }}.allTests),
+{% endif %}{% endfor %}])
+// sourcery:end

--- a/scripts/update-linux-main.sh
+++ b/scripts/update-linux-main.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pushd "$SCRIPTS_DIR/.." > /dev/null
+
+sourcery \
+    --sources Tests \
+    --templates "$SCRIPTS_DIR/LinuxMain.stencil" \
+    --args testimports='@testable import ICUTests'
+
+popd > /dev/null


### PR DESCRIPTION
This PR contains some changes intended to make the tests run on Linux, but there are deeper issues preventing it from working there (related to the renaming that occurs in the library symbols).