### PR TITLE
Add break cursors (wrapping ICU break iterators)

### DIFF
--- a/Sources/ICU/BreakCursorImpl.swift
+++ b/Sources/ICU/BreakCursorImpl.swift
@@ -1,0 +1,266 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Provides the actual implementation of a break cursor.
+///
+/// This type allows the concrete break cursor types to handle creation of the
+/// ICU cursor object (using `ubrk_open` or `ubrk_openRules`) and the precise
+/// type used to represent rule status tags but otherwise share the
+/// implementation of the other operations.
+internal struct BreakCursorImpl<RuleStatus> {
+
+  /// The string being scanned by the cursor.
+  var text: String? {
+    didSet {
+      textPointer?.deallocate()
+      if let text = text {
+        textPointer = text.unsafeUTF16CodeUnits()
+
+        var error = UErrorCode()
+        ubrk_setText(
+          cBreak,
+          textPointer?.baseAddress,
+          Int32(textPointer?.count ?? 0),
+          &error)
+      }
+    }
+  }
+
+  /// The most recently returned text boundary.
+  var index: String.Index? {
+    let offset = ubrk_current(cBreak)
+    guard let result = stringIndex(forUTF16Offset: offset) else {
+      preconditionFailure("Break cursor index was not valid")
+    }
+    return result
+  }
+
+  /// The status tag from the break rule that determined the most recently
+  /// returned break position.
+  ///
+  /// If more than one break rule applied at the current position, then the
+  /// numerically largest status tag is returned.
+  var ruleStatus: RuleStatus {
+    return ruleStatusFactory(Int(ubrk_getRuleStatus(cBreak)))
+  }
+
+  /// The status tags from the break rules that determined the most recently
+  /// returned break position.
+  var ruleStatuses: [RuleStatus] {
+    var error = UErrorCode()
+    let capacity = ubrk_getRuleStatusVec(cBreak, nil, 0, &error)
+
+    var rawStatuses = [Int32](repeating: 0, count: Int(capacity))
+    rawStatuses.withUnsafeMutableBufferPointer { buffer in
+      error = UErrorCode()
+      _ = ubrk_getRuleStatusVec(cBreak, buffer.baseAddress, capacity, &error)
+    }
+    return rawStatuses.map { ruleStatusFactory(Int($0)) }
+  }
+
+  /// The pointer to the underlying C ICU break iterator object.
+  private var cBreak: OpaquePointer
+
+  /// The pointer to the UTF-16 code units of the text being scanned by the
+  /// break iterator.
+  private var textPointer: UnsafeMutableBufferPointer<UChar>?
+
+  /// The function that converts the integer value of a rule status tag to a
+  /// typed value.
+  private var ruleStatusFactory: (Int) -> RuleStatus
+
+  /// Creates a new break cursor implementation that wraps an already-created
+  /// ICU break iterator.
+  ///
+  /// - Parameters:
+  ///   - cBreak: The ICU break iterator object.
+  ///   - text: The text string to be iterated over.
+  ///   - textPointer: A pointer to a copy of the UTF-16 code units of `text`.
+  init(
+    cBreak: OpaquePointer,
+    text: String?,
+    textPointer: UnsafeMutableBufferPointer<UChar>?,
+    ruleStatusFactory: @escaping (Int) -> RuleStatus
+  ) {
+    self.cBreak = cBreak
+    self.text = text
+    self.textPointer = textPointer
+    self.ruleStatusFactory = ruleStatusFactory
+  }
+
+  /// Creates a new break cursor of the given type.
+  ///
+  /// - Parameters:
+  ///   - type: The ICU break iterator type.
+  ///   - text: The text string to be iterated over.
+  ///   - locale: The locale used to determine the language rules for text
+  ///     breaking.
+  init(
+    type: UBreakIteratorType,
+    text: String?,
+    locale: String?,
+    ruleStatusFactory: @escaping (Int) -> RuleStatus
+  ) {
+    let textPointer = text?.unsafeUTF16CodeUnits()
+
+    var error = UErrorCode()
+    let cBreak = ubrk_open(
+      type,
+      locale ?? String(cString: uloc_getDefault()),
+      textPointer?.baseAddress,
+      Int32(truncatingIfNeeded: textPointer?.count ?? 0),
+      &error)
+
+    self.init(
+      cBreak: cBreak!,
+      text: text,
+      textPointer: textPointer,
+      ruleStatusFactory: ruleStatusFactory)
+  }
+
+  /// Closes the underlying ICU break iterator and frees the memory used to
+  /// manage the current copy of the text.
+  func release() {
+    ubrk_close(cBreak)
+    textPointer?.deallocate()
+  }
+
+  /// Returns the start index of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// text's starting index.
+  ///
+  /// - Returns: The start index of the text being scanned.
+  func first() -> String.Index {
+    let result = ubrk_first(cBreak)
+    return stringIndex(forUTF16Offset: result)!
+  }
+
+  /// Returns the index past the last character of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// index past the last character of the text.
+  ///
+  /// - Returns: The index past the last character of the text being scanned.
+  func last() -> String.Index {
+    let result = ubrk_last(cBreak)
+    return stringIndex(forUTF16Offset: result)!
+  }
+
+  /// Returns the index of the boundary following the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the next boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the next boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  func next() -> String.Index? {
+    let result = ubrk_next(cBreak)
+    guard result != UBRK_DONE else { return nil }
+    return stringIndex(forUTF16Offset: result)
+  }
+
+  /// Returns the index of the boundary preceding the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the previous boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the previous boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  func previous() -> String.Index? {
+    let result = ubrk_previous(cBreak)
+    guard result != UBRK_DONE else { return nil }
+    return stringIndex(forUTF16Offset: result)
+  }
+
+  /// Returns the first index greater than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// after `index`.
+  ///
+  /// - Parameter index: The index at which scanning should begin.
+  /// - Returns: The index of the first boundary following `index`, or nil if no
+  ///   boundaries were found.
+  func moveToIndex(following index: String.Index) -> String.Index? {
+    let offset = utf16Offset(forStringIndex: index)
+    let result = ubrk_following(cBreak, offset)
+    guard result != USEARCH_DONE else { return nil }
+    return stringIndex(forUTF16Offset: result)
+  }
+
+  /// Returns the first index less than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// before `index`.
+  ///
+  /// - Parameter index: The index at which the scanning should begin.
+  /// - Returns: The index of the first boundary preceding `index`, or nil if no
+  ///   boundaries were found.
+  func moveToIndex(preceding index: String.Index) -> String.Index? {
+    let offset = utf16Offset(forStringIndex: index)
+    let result = ubrk_preceding(cBreak, offset)
+    guard result != USEARCH_DONE else { return nil }
+    return stringIndex(forUTF16Offset: result)
+  }
+
+  /// Returns true if the given index represents a boundary position in the
+  /// cursor's text, also moving the cursor to the first boundary at or
+  /// following that index.
+  ///
+  /// - Parameter index: The index to check.
+  /// - Returns: True if the given index is a boundary position.
+  func isBoundary(movingToOrAfter index: String.Index) -> Bool {
+    let offset = utf16Offset(forStringIndex: index)
+    return ubrk_isBoundary(cBreak, offset) != 0
+  }
+
+  /// Returns the index in the string being searched that corresponds to the
+  /// given offset in its UTF-16 code units.
+  ///
+  /// - Parameters offset: An integer offset in the UTF-16 code units of the
+  ///   string being searched.
+  /// - Returns: The corresponding string index.
+  private func stringIndex(forUTF16Offset offset: Int32) -> String.Index? {
+    guard let text = text else { return nil }
+    let utf16 = text.utf16
+    return utf16.index(
+      utf16.startIndex,
+      offsetBy: Int(offset)
+    ).samePosition(in: text)
+  }
+
+  /// Returns the offset in UTF-16 code units corresponding to an index in the
+  /// string being searched.
+  ///
+  /// - Parameter index: An index into the string being searched.
+  /// - Returns: The integer offset in UTF-16 code units corresponding to the
+  ///   index.
+  private func utf16Offset(forStringIndex index: String.Index) -> Int32 {
+    guard let text = text else { return 0 }
+    let utf16 = text.utf16
+    guard let utf16Index = index.samePosition(in: utf16) else {
+      preconditionFailure("String index must be UTF-16 aligned")
+    }
+    let offset = utf16.distance(from: utf16.startIndex, to: utf16Index)
+    return Int32(truncatingIfNeeded: offset)
+  }
+}

--- a/Sources/ICU/BreakRuleParseError.swift
+++ b/Sources/ICU/BreakRuleParseError.swift
@@ -1,0 +1,100 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Errors that can be thrown when creating a `RuleBasedBreakCursor`.
+public enum BreakRuleParseError: Error {
+
+  /// An internal error (bug) was detected.
+  case internalError(context: ParseErrorContext)
+
+  /// Hexadecimal digits were expected but not found (e.g., part of an escaped
+  /// character in a rule).
+  case hexDigitsExpected(context: ParseErrorContext)
+
+  /// The semicolon was missing at the end of a rule.
+  case semicolonExpected(context: ParseErrorContext)
+
+  /// There was a syntax error in a rule.
+  case ruleSyntax(context: ParseErrorContext)
+
+  /// A Unicode set within a rule was missing the closing "]".
+  case unclosedSet(context: ParseErrorContext)
+
+  /// There was a syntax error in a rule assignment statement.
+  case assignError(context: ParseErrorContext)
+
+  /// A `$variable` was redefined.
+  case variableRedefinition(context: ParseErrorContext)
+
+  /// There were mismatched parentheses in a rule.
+  case mismatchedParentheses(context: ParseErrorContext)
+
+  /// There was a missing closing quote in a rule.
+  case newLineInQuotedString(context: ParseErrorContext)
+
+  /// A `$variable` was used that was not defined.
+  case undefinedVariable(context: ParseErrorContext)
+
+  /// An error occurred during initialization (maybe ICU data is missing?).
+  case initializationError(context: ParseErrorContext)
+
+  /// A rule contained an empty Unicode set.
+  case ruleEmptySet(context: ParseErrorContext)
+
+  /// An `!!option` in a rule was not recognized.
+  case unrecognizedOption(context: ParseErrorContext)
+
+  /// The `{nnn}` tag on a rule was malformed.
+  case malformedRuleTag(context: ParseErrorContext)
+
+  /// Creates a new parse error with the given ICU error code and context.
+  ///
+  /// - Parameters:
+  ///   - cValue: The underlying ICU C error code.
+  ///   - context: The `ParseErrorContext` that describes where the error
+  ///     occurred during parsing.
+  init(cValue: UErrorCode, context: ParseErrorContext) {
+    let factory: (ParseErrorContext) -> BreakRuleParseError
+
+    switch cValue {
+    case U_BRK_INTERNAL_ERROR: factory = BreakRuleParseError.internalError
+    case U_BRK_HEX_DIGITS_EXPECTED:
+      factory = BreakRuleParseError.hexDigitsExpected
+    case U_BRK_SEMICOLON_EXPECTED:
+      factory = BreakRuleParseError.semicolonExpected
+    case U_BRK_RULE_SYNTAX: factory = BreakRuleParseError.ruleSyntax
+    case U_BRK_UNCLOSED_SET: factory = BreakRuleParseError.unclosedSet
+    case U_BRK_ASSIGN_ERROR: factory = BreakRuleParseError.assignError
+    case U_BRK_VARIABLE_REDFINITION:
+      factory = BreakRuleParseError.variableRedefinition
+    case U_BRK_MISMATCHED_PAREN:
+      factory = BreakRuleParseError.mismatchedParentheses
+    case U_BRK_NEW_LINE_IN_QUOTED_STRING:
+      factory = BreakRuleParseError.newLineInQuotedString
+    case U_BRK_UNDEFINED_VARIABLE:
+      factory = BreakRuleParseError.undefinedVariable
+    case U_BRK_INIT_ERROR: factory = BreakRuleParseError.initializationError
+    case U_BRK_RULE_EMPTY_SET: factory = BreakRuleParseError.ruleEmptySet
+    case U_BRK_UNRECOGNIZED_OPTION:
+      factory = BreakRuleParseError.unrecognizedOption
+    case U_BRK_MALFORMED_RULE_TAG:
+      factory = BreakRuleParseError.malformedRuleTag
+    default: fatalError("Internal error: error code not supported")
+    }
+
+    self = factory(context)
+  }
+}

--- a/Sources/ICU/CharacterBreakCursor.swift
+++ b/Sources/ICU/CharacterBreakCursor.swift
@@ -1,0 +1,152 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Provides an interface for efficiently locating character boundaries in a
+/// text string.
+///
+/// Note that this cursor essentially provides the same informatio that Swift's
+/// own treatment of `String` as a collection of `Character` values provides. It
+/// is included primarily for API completeness.
+///
+/// Unlike other cursor types, character break cursors do not surface rule
+/// status values.
+///
+/// **Terminology note:** The name "cursor" has been chosen instead of
+/// "iterator" to better map to the concepts found in Swift. Swift's iterator
+/// types provide unidirectional traversal of a sequence; by contrast, a
+/// "cursor" more accurately describes this type, which can move forward and
+/// backward arbitrarily within a string.
+public final class CharacterBreakCursor {
+
+  /// The actual break cursor implementation to which this class's operations
+  /// are delegated.
+  private var impl: BreakCursorImpl<Void>
+
+  /// The text being scanned by the cursor.
+  public var text: String? {
+    get { return impl.text }
+    set { impl.text = newValue }
+  }
+
+  /// The most recently returned text boundary.
+  public var index: String.Index? {
+    return impl.index
+  }
+
+  /// The locale used to determine the language rules for text breaking.
+  public let locale: String?
+
+  /// Creates a new character break cursor with the given rules.
+  ///
+  /// - Parameters:
+  ///   - text: The optional initial text that the cursor will scan.
+  ///   - locale: The locale used to determine the language rules for text
+  ///     breaking.
+  public init(text: String? = nil, locale: String? = nil) {
+    self.locale = locale
+    self.impl = BreakCursorImpl(
+      type: UBRK_CHARACTER,
+      text: text,
+      locale: locale
+    ) { _ in () }
+  }
+
+  deinit {
+    impl.release()
+  }
+
+  /// Returns the start index of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// text's starting index.
+  ///
+  /// - Returns: The start index of the text being scanned.
+  public func first() -> String.Index {
+    return impl.first()
+  }
+
+  /// Returns the index past the last character of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// index past the last character of the text.
+  ///
+  /// - Returns: The index past the last character of the text being scanned.
+  public func last() -> String.Index {
+    return impl.last()
+  }
+
+  /// Returns the index of the boundary following the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the next boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the next boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func next() -> String.Index? {
+    return impl.next()
+  }
+
+  /// Returns the index of the boundary preceding the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the previous boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the previous boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func previous() -> String.Index? {
+    return impl.previous()
+  }
+
+  /// Returns the first index greater than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// after `index`.
+  ///
+  /// - Parameter index: The index at which scanning should begin.
+  /// - Returns: The index of the first boundary following `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(following index: String.Index) -> String.Index? {
+    return impl.moveToIndex(following: index)
+  }
+
+  /// Returns the first index less than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// before `index`.
+  ///
+  /// - Parameter index: The index at which the scanning should begin.
+  /// - Returns: The index of the first boundary preceding `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(preceding index: String.Index) -> String.Index? {
+    return impl.moveToIndex(preceding: index)
+  }
+
+  /// Returns true if the given index represents a boundary position in the
+  /// cursor's text, also moving the cursor to the first boundary at or
+  /// following that index.
+  ///
+  /// - Parameter index: The index to check.
+  /// - Returns: True if the given index is a boundary position.
+  public func isBoundary(movingToOrAfter index: String.Index) -> Bool {
+    return impl.isBoundary(movingToOrAfter: index)
+  }
+}

--- a/Sources/ICU/LineBreakCursor.swift
+++ b/Sources/ICU/LineBreakCursor.swift
@@ -1,0 +1,235 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Provides an interface for efficiently locating line boundaries in a text
+/// string.
+///
+/// ICU defines the rule status tags for line breaks as _ranges_, which allows
+/// future versions to subdivide tag groups into finer subcategories. Because of
+/// this, they should not (and cannot) be compared using `==`. Instead, use
+/// pattern matching (i.e., `if case`, `switch`, or the `~=` operator directly)
+/// to determine if a status tag belongs to one of the known categories:
+///
+/// ```swift
+/// if case .soft = cursor.ruleStatus {
+///   // do something
+/// }
+/// ```
+///
+/// **Terminology note:** The name "cursor" has been chosen instead of
+/// "iterator" to better map to the concepts found in Swift. Swift's iterator
+/// types provide unidirectional traversal of a sequence; by contrast, a
+/// "cursor" more accurately describes this type, which can move forward and
+/// backward arbitrarily within a string.
+public final class LineBreakCursor {
+
+  /// Represents the status tag from a break rule.
+  public struct RuleStatus {
+
+    /// The raw integer value of the status tag.
+    public let rawValue: Int
+
+    /// Creates a new `RuleStatus` value with the given integer value.
+    ///
+    /// - Parameter rawValue: The integer value of the status tag.
+    init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+  }
+
+  /// Represents a range of status tags from a break rule.
+  ///
+  /// The rule status tags for word breaks are meant to be treated as ranges,
+  /// not exact values; this allows future versions of the library to further
+  /// subdivide a break rule's tags. Thus, `RuleStatus` values should not be
+  /// compared using equality, but instead use the `~=` operator (directly, or
+  /// through pattern matching):
+  ///
+  /// ```swift
+  /// if case .soft = cursor.ruleStatus {
+  ///   // do something
+  /// }
+  /// ```
+  public struct RuleStatusRange {
+
+    /// The range of integer values.
+    private let range: Range<Int>
+
+    /// Creates a new rule status range from a range of unsigned integers.
+    ///
+    /// - Parameter range: The range of unsigned integers.
+    private init(_ range: Range<UInt32>) {
+      self.range = Int(range.lowerBound)..<Int(range.upperBound)
+    }
+
+    /// The rule status range for soft line breaks—positions at which a line
+    /// break is acceptable but not required.
+    public static let soft = RuleStatusRange(
+      UBRK_LINE_SOFT.rawValue..<UBRK_LINE_SOFT_LIMIT.rawValue)
+
+    /// The rule status range for hard (mandatory) line breaks.
+    public static let hard = RuleStatusRange(
+      UBRK_LINE_HARD.rawValue..<UBRK_LINE_HARD_LIMIT.rawValue)
+
+    /// Returns true if the range contains the given rule status tag.
+    ///
+    /// - Parameters:
+    ///   - range: The rule status range.
+    ///   - ruleStatus: The rule status.
+    /// - Returns: True if the range contains the given rule status tag.
+    public static func ~= (
+      range: RuleStatusRange,
+      ruleStatus: RuleStatus
+    ) -> Bool {
+      return range.range.contains(ruleStatus.rawValue)
+    }
+  }
+
+  /// The status tag from the break rule that determined the most recently
+  /// returned break position.
+  ///
+  /// If more than one break rule applied at the current position, then the
+  /// numerically largest status tag is returned.
+  public var ruleStatus: RuleStatus {
+    return impl.ruleStatus
+  }
+
+  /// The status tags from the break rules that determined the most recently
+  /// returned break position.
+  public var ruleStatuses: [RuleStatus] {
+    return impl.ruleStatuses
+  }
+
+  /// The actual break cursor implementation to which this class's operations
+  /// are delegated.
+  private var impl: BreakCursorImpl<RuleStatus>
+
+  /// The text being scanned by the cursor.
+  public var text: String? {
+    get { return impl.text }
+    set { impl.text = newValue }
+  }
+
+  /// The most recently returned text boundary.
+  public var index: String.Index? {
+    return impl.index
+  }
+
+  /// The locale used to determine the language rules for text breaking.
+  public let locale: String?
+
+  /// Creates a new line break cursor with the given rules.
+  ///
+  /// - Parameters:
+  ///   - text: The optional initial text that the cursor will scan.
+  ///   - locale: The locale used to determine the language rules for text
+  ///     breaking.
+  public init(text: String? = nil, locale: String? = nil) {
+    self.locale = locale
+    self.impl = BreakCursorImpl(
+      type: UBRK_LINE,
+      text: text,
+      locale: locale,
+      ruleStatusFactory: RuleStatus.init)
+  }
+
+  deinit {
+    impl.release()
+  }
+
+  /// Returns the start index of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// text's starting index.
+  ///
+  /// - Returns: The start index of the text being scanned.
+  public func first() -> String.Index {
+    return impl.first()
+  }
+
+  /// Returns the index past the last character of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// index past the last character of the text.
+  ///
+  /// - Returns: The index past the last character of the text being scanned.
+  public func last() -> String.Index {
+    return impl.last()
+  }
+
+  /// Returns the index of the boundary following the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the next boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the next boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func next() -> String.Index? {
+    return impl.next()
+  }
+
+  /// Returns the index of the boundary preceding the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the previous boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the previous boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func previous() -> String.Index? {
+    return impl.previous()
+  }
+
+  /// Returns the first index greater than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// after `index`.
+  ///
+  /// - Parameter index: The index at which scanning should begin.
+  /// - Returns: The index of the first boundary following `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(following index: String.Index) -> String.Index? {
+    return impl.moveToIndex(following: index)
+  }
+
+  /// Returns the first index less than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// before `index`.
+  ///
+  /// - Parameter index: The index at which the scanning should begin.
+  /// - Returns: The index of the first boundary preceding `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(preceding index: String.Index) -> String.Index? {
+    return impl.moveToIndex(preceding: index)
+  }
+
+  /// Returns true if the given index represents a boundary position in the
+  /// cursor's text, also moving the cursor to the first boundary at or
+  /// following that index.
+  ///
+  /// - Parameter index: The index to check.
+  /// - Returns: True if the given index is a boundary position.
+  public func isBoundary(movingToOrAfter index: String.Index) -> Bool {
+    return impl.isBoundary(movingToOrAfter: index)
+  }
+}
+

--- a/Sources/ICU/ParseErrorContext.swift
+++ b/Sources/ICU/ParseErrorContext.swift
@@ -1,0 +1,76 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Represents the location and text content of an error that occurred while
+/// parsing source text, such as break cursor rules.
+public struct ParseErrorContext {
+
+  /// Indicates where in the source text the error occurred.
+  ///
+  /// Parsers that support line numbers will return locations using the
+  /// `lineAndColumn` case. Parsers that do not support them will only return
+  /// locations that are case `offset`.
+  public enum Location {
+
+    /// The line number and column offset (both starting at 1) where the error
+    /// occurred.
+    case lineAndColumn(line: Int, column: Int)
+
+    /// The offset (in terms of UTF-16 code units) in the source text where the
+    /// error occurred.
+    case offset(Int)
+  }
+
+  /// The location where the error occurred in the source text.
+  public let location: Location
+
+  /// Some textual context before the error.
+  ///
+  /// If the parser does not support this, it will be empty.
+  public let preContext: String
+
+  /// The textual content of the error itself and some trailing content.
+  ///
+  /// If the parser does not support this, it will be empty.
+  public let postContext: String
+
+  /// Creates a new `ParseErrorContext` from the given ICU C value.
+  ///
+  /// - Parameter cValue: The `UParseError` value from an ICU C API that
+  ///   describes the error context.
+  init(cValue: UParseError) {
+    if cValue.line >= 1 {
+      self.location =
+        .lineAndColumn(line: Int(cValue.line), column: Int(cValue.offset))
+    } else {
+      self.location = .offset(Int(cValue.offset))
+    }
+
+    var cValueCopy = cValue
+    self.preContext = withUnsafeBytes(of: &cValueCopy.preContext) {
+      (rawPointer) in
+      let codeUnitPointer =
+        rawPointer.baseAddress!.assumingMemoryBound(to: UChar.self)
+      return String(unsafeUTF16CodeUnits: codeUnitPointer)
+    }
+    self.postContext = withUnsafeBytes(of: &cValueCopy.postContext) {
+      (rawPointer) in
+      let codeUnitPointer =
+        rawPointer.baseAddress!.assumingMemoryBound(to: UChar.self)
+      return String(unsafeUTF16CodeUnits: codeUnitPointer)
+    }
+  }
+}

--- a/Sources/ICU/RuleBasedBreakCursor.swift
+++ b/Sources/ICU/RuleBasedBreakCursor.swift
@@ -1,0 +1,237 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Provides an interface for efficiently locating boundaries in a text string
+/// based on a set of custom rules described using a string-based encoding.
+///
+/// The generic `RuleStatus` type argument itself is unconstrained, but through
+/// extensions this cursor can only be instantiated when `RuleStatus` is one of
+/// the following types, and instances of these types will be returned by the
+/// `ruleStatus` and `ruleStatuses` properties:
+///
+/// 1. Anything conforming to `RawRepresentable` where `RawValue == Int`
+/// 1. `Int` itself
+///
+/// In the first case, the `RuleStatus` type must have a value for all of the
+/// tags that you specify in your rules, and also for zero; missing values will
+/// result in a runtime failure. In the second case, querying `ruleStatus(es)`
+/// simply returns the raw integer.
+///
+/// **Terminology note:** The name "cursor" has been chosen instead of
+/// "iterator" to better map to the concepts found in Swift. Swift's iterator
+/// types provide unidirectional traversal of a sequence; by contrast, a
+/// "cursor" more accurately describes this type, which can move forward and
+/// backward arbitrarily within a string.
+public final class RuleBasedBreakCursor<RuleStatus> {
+
+  /// The text being scanned by the cursor.
+  public var text: String? {
+    get { return impl.text }
+    set { impl.text = newValue }
+  }
+
+  /// The status tag from the break rule that determined the most recently
+  /// returned break position.
+  ///
+  /// If more than one break rule applied at the current position, then the
+  /// numerically largest status tag is returned.
+  public var ruleStatus: RuleStatus {
+    return impl.ruleStatus
+  }
+
+  /// The status tags from the break rules that determined the most recently
+  /// returned break position.
+  public var ruleStatuses: [RuleStatus] {
+    return impl.ruleStatuses
+  }
+
+  /// The actual break cursor implementation to which this class's operations
+  /// are delegated.
+  private var impl: BreakCursorImpl<RuleStatus>
+
+  /// The string representation of the break rules used by the cursor.
+  public let rules: String
+
+  /// A pointer to a copy of the UTF-16 code units in `rules`.
+  private var rulesPointer: UnsafeMutableBufferPointer<UChar>
+
+  /// The most recently returned text boundary.
+  public var index: String.Index? {
+    return impl.index
+  }
+
+  /// This is the designated initializer, which is internal. it is called by
+  /// the public convenience initializers, which allow public instantiation of
+  /// `RuleBasedBreakIterator` for generic type arguments that satisfy specific
+  /// constraints.
+  ///
+  /// - Parameters:
+  ///   - rules: The string representation of the break rules used by the
+  ///     cursor.
+  ///   - text: The optional initial text that the cursor will scan.
+  ///   - ruleStatusFactory: A function that converts the raw integer values of
+  ///     rule status tags into instances of the generic `RuleStatus` type.
+  /// - Throws: `BreakRuleParseError` if an error occurs while parsing the
+  ///   rules.
+  internal init(
+    rules: String,
+    text: String?,
+    ruleStatusFactory: @escaping (Int) -> RuleStatus
+  ) throws {
+    self.rules = rules
+    self.rulesPointer = rules.unsafeUTF16CodeUnits()
+    let textPointer = text?.unsafeUTF16CodeUnits()
+
+    var parseError = UParseError()
+    var error = UErrorCode()
+    let cBreak = ubrk_openRules(
+      rulesPointer.baseAddress!,
+      Int32(truncatingIfNeeded: rulesPointer.count),
+      textPointer?.baseAddress,
+      Int32(truncatingIfNeeded: textPointer?.count ?? 0),
+      &parseError,
+      &error)
+
+    guard error.isSuccess else {
+      let errorContext = ParseErrorContext(cValue: parseError)
+      throw BreakRuleParseError(cValue: error, context: errorContext)
+    }
+
+    impl = BreakCursorImpl(
+      cBreak: cBreak!,
+      text: text,
+      textPointer: textPointer,
+      ruleStatusFactory: ruleStatusFactory)
+  }
+
+  deinit {
+    impl.release()
+    rulesPointer.deallocate()
+  }
+
+  /// Returns the start index of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// text's starting index.
+  ///
+  /// - Returns: The start index of the text being scanned.
+  public func first() -> String.Index {
+    return impl.first()
+  }
+
+  /// Returns the index past the last character of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// index past the last character of the text.
+  ///
+  /// - Returns: The index past the last character of the text being scanned.
+  public func last() -> String.Index {
+    return impl.last()
+  }
+
+  /// Returns the index of the boundary following the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the next boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the next boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func next() -> String.Index? {
+    return impl.next()
+  }
+
+  /// Returns the index of the boundary preceding the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the previous boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the previous boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func previous() -> String.Index? {
+    return impl.previous()
+  }
+
+  /// Returns the first index greater than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// after `index`.
+  ///
+  /// - Parameter index: The index at which scanning should begin.
+  /// - Returns: The index of the first boundary following `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(following index: String.Index) -> String.Index? {
+    return impl.moveToIndex(following: index)
+  }
+
+  /// Returns the first index less than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// before `index`.
+  ///
+  /// - Parameter index: The index at which the scanning should begin.
+  /// - Returns: The index of the first boundary preceding `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(preceding index: String.Index) -> String.Index? {
+    return impl.moveToIndex(preceding: index)
+  }
+
+  /// Returns true if the given index represents a boundary position in the
+  /// cursor's text, also moving the cursor to the first boundary at or
+  /// following that index.
+  ///
+  /// - Parameter index: The index to check.
+  /// - Returns: True if the given index is a boundary position.
+  public func isBoundary(movingToOrAfter index: String.Index) -> Bool {
+    return impl.isBoundary(movingToOrAfter: index)
+  }
+}
+
+extension RuleBasedBreakCursor
+where RuleStatus: RawRepresentable, RuleStatus.RawValue == Int {
+
+  /// Creates a new rule-based break cursor with the given rules.
+  ///
+  /// - Parameters:
+  ///   - rules: The string representation of the break rules used by the
+  ///     cursor.
+  ///   - text: The optional initial text that the cursor will scan.
+  /// - Throws: `BreakRuleParseError` if an error occurs while parsing the
+  ///   rules.
+  public convenience init(rules: String, text: String? = nil) throws {
+    try self.init(rules: rules, text: text) { RuleStatus(rawValue: $0)! }
+  }
+}
+
+extension RuleBasedBreakCursor where RuleStatus == Int {
+
+  /// Creates a new rule-based break cursor with the given rules.
+  ///
+  /// - Parameters:
+  ///   - rules: The string representation of the break rules used by the
+  ///     cursor.
+  ///   - text: The optional initial text that the cursor will scan.
+  /// - Throws: `BreakRuleParseError` if an error occurs while parsing the
+  ///   rules.
+  public convenience init(rules: String, text: String? = nil) throws {
+    try self.init(rules: rules, text: text) { $0 }
+  }
+}

--- a/Sources/ICU/SentenceBreakCursor.swift
+++ b/Sources/ICU/SentenceBreakCursor.swift
@@ -1,0 +1,241 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Provides an interface for efficiently locating sentence boundaries in a text
+/// string.
+///
+/// ICU defines the rule status tags for sentence breaks as _ranges_, which
+/// allows future versions to subdivide tag groups into finer subcategories.
+/// Because of this, they should not (and cannot) be compared using `==`.
+/// Instead, use pattern matching (i.e., `if case`, `switch`, or the `~=`
+/// operator directly) to determine if a status tag belongs to one of the known
+/// categories:
+///
+/// ```swift
+/// if case .separator = cursor.ruleStatus {
+///   // do something
+/// }
+/// ```
+///
+/// **Terminology note:** The name "cursor" has been chosen instead of
+/// "iterator" to better map to the concepts found in Swift. Swift's iterator
+/// types provide unidirectional traversal of a sequence; by contrast, a
+/// "cursor" more accurately describes this type, which can move forward and
+/// backward arbitrarily within a string.
+public final class SentenceBreakCursor {
+
+  /// Represents the status tag from a break rule.
+  public struct RuleStatus {
+
+    /// The raw integer value of the status tag.
+    public let rawValue: Int
+
+    /// Creates a new `RuleStatus` value with the given integer value.
+    ///
+    /// - Parameter rawValue: The integer value of the status tag.
+    init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+  }
+
+  /// Represents a range of status tags from a break rule.
+  ///
+  /// The rule status tags for word breaks are meant to be treated as ranges,
+  /// not exact values; this allows future versions of the library to further
+  /// subdivide a break rule's tags. Thus, `RuleStatus` values should not be
+  /// compared using equality, but instead use the `~=` operator (directly, or
+  /// through pattern matching):
+  ///
+  /// ```swift
+  /// if case .separator = cursor.ruleStatus {
+  ///   // do something
+  /// }
+  /// ```
+  public struct RuleStatusRange {
+
+    /// The range of integer values.
+    private let range: Range<Int>
+
+    /// Creates a new rule status range from a range of unsigned integers.
+    ///
+    /// - Parameter range: The range of unsigned integers.
+    private init(_ range: Range<UInt32>) {
+      self.range = Int(range.lowerBound)..<Int(range.upperBound)
+    }
+
+    /// The rule status range for sentences ending with a sentence terminator
+    /// character (period, question mark, exclamation point, etc.), possibly
+    /// followed by a hard separator (carriage return, line feed, paragraph
+    /// separator, etc.).
+    public static let terminator = RuleStatusRange(
+      UBRK_SENTENCE_TERM.rawValue..<UBRK_SENTENCE_TERM_LIMIT.rawValue)
+
+    /// The rule status range for sentences that do not contain a sentence
+    /// terminator character (period, question mark, exclamation point, etc.),
+    /// but are ended only by a hard separator (carriage return, line feed,
+    /// paragraph separator, etc.).
+    public static let separator = RuleStatusRange(
+      UBRK_SENTENCE_SEP.rawValue..<UBRK_SENTENCE_SEP_LIMIT.rawValue)
+
+    /// Returns true if the range contains the given rule status tag.
+    ///
+    /// - Parameters:
+    ///   - range: The rule status range.
+    ///   - ruleStatus: The rule status.
+    /// - Returns: True if the range contains the given rule status tag.
+    public static func ~= (
+      range: RuleStatusRange,
+      ruleStatus: RuleStatus
+    ) -> Bool {
+      return range.range.contains(ruleStatus.rawValue)
+    }
+  }
+
+  /// The status tag from the break rule that determined the most recently
+  /// returned break position.
+  ///
+  /// If more than one break rule applied at the current position, then the
+  /// numerically largest status tag is returned.
+  public var ruleStatus: RuleStatus {
+    return impl.ruleStatus
+  }
+
+  /// The status tags from the break rules that determined the most recently
+  /// returned break position.
+  public var ruleStatuses: [RuleStatus] {
+    return impl.ruleStatuses
+  }
+
+  /// The actual break cursor implementation to which this class's operations
+  /// are delegated.
+  private var impl: BreakCursorImpl<RuleStatus>
+
+  /// The text being scanned by the cursor.
+  public var text: String? {
+    get { return impl.text }
+    set { impl.text = newValue }
+  }
+
+  /// The most recently returned text boundary.
+  public var index: String.Index? {
+    return impl.index
+  }
+
+  /// The locale used to determine the language rules for text breaking.
+  public let locale: String?
+
+  /// Creates a new sentence break cursor with the given rules.
+  ///
+  /// - Parameters:
+  ///   - text: The optional initial text that the cursor will scan.
+  ///   - locale: The locale used to determine the language rules for text
+  ///     breaking.
+  public init(text: String? = nil, locale: String? = nil) {
+    self.locale = locale
+    self.impl = BreakCursorImpl(
+      type: UBRK_SENTENCE,
+      text: text,
+      locale: locale,
+      ruleStatusFactory: RuleStatus.init)
+  }
+
+  deinit {
+    impl.release()
+  }
+
+  /// Returns the start index of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// text's starting index.
+  ///
+  /// - Returns: The start index of the text being scanned.
+  public func first() -> String.Index {
+    return impl.first()
+  }
+
+  /// Returns the index past the last character of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// index past the last character of the text.
+  ///
+  /// - Returns: The index past the last character of the text being scanned.
+  public func last() -> String.Index {
+    return impl.last()
+  }
+
+  /// Returns the index of the boundary following the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the next boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the next boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func next() -> String.Index? {
+    return impl.next()
+  }
+
+  /// Returns the index of the boundary preceding the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the previous boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the previous boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func previous() -> String.Index? {
+    return impl.previous()
+  }
+
+  /// Returns the first index greater than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// after `index`.
+  ///
+  /// - Parameter index: The index at which scanning should begin.
+  /// - Returns: The index of the first boundary following `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(following index: String.Index) -> String.Index? {
+    return impl.moveToIndex(following: index)
+  }
+
+  /// Returns the first index less than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// before `index`.
+  ///
+  /// - Parameter index: The index at which the scanning should begin.
+  /// - Returns: The index of the first boundary preceding `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(preceding index: String.Index) -> String.Index? {
+    return impl.moveToIndex(preceding: index)
+  }
+
+  /// Returns true if the given index represents a boundary position in the
+  /// cursor's text, also moving the cursor to the first boundary at or
+  /// following that index.
+  ///
+  /// - Parameter index: The index to check.
+  /// - Returns: True if the given index is a boundary position.
+  public func isBoundary(movingToOrAfter index: String.Index) -> Bool {
+    return impl.isBoundary(movingToOrAfter: index)
+  }
+}
+

--- a/Sources/ICU/String+UTF16.swift
+++ b/Sources/ICU/String+UTF16.swift
@@ -16,6 +16,38 @@ import ICU4C
 
 extension String {
 
+  /// Creates a new `String` from the given pointer to a buffer containing
+  /// null-terminated UTF-16 code units.
+  ///
+  /// - Parameter pointer: A pointer to a buffer containing null-terminated
+  ///   UTF-16 code units.
+  internal init(unsafeUTF16CodeUnits pointer: UnsafePointer<UChar>) {
+    var codec = UTF16()
+    var result = ""
+
+    var iteratingPointer = pointer
+    var iterator = AnyIterator<UChar> {
+      let uchar = iteratingPointer.pointee
+      if uchar == 0 {
+        return nil
+      }
+      iteratingPointer = iteratingPointer.advanced(by: 1)
+      return uchar
+    }
+
+    decode: while true {
+      switch codec.decode(&iterator) {
+      case .scalarValue(let scalar): result.unicodeScalars.append(scalar)
+      case .emptyInput: break decode
+      case .error:
+        print("Decoding error")
+        break decode
+      }
+    }
+
+    self = result
+  }
+
   /// Returns a buffer pointer to a copy of the UTF-16 code units of the
   /// receiver.
   ///

--- a/Sources/ICU/WordBreakCursor.swift
+++ b/Sources/ICU/WordBreakCursor.swift
@@ -1,0 +1,247 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU4C
+
+/// Provides an interface for efficiently locating word boundaries in a text
+/// string.
+///
+/// ICU defines the rule status tags for word breaks as _ranges_, which allows
+/// future versions to subdivide tag groups into finer subcategories. Because of
+/// this, they should not (and cannot) be compared using `==`. Instead, use
+/// pattern matching (i.e., `if case`, `switch`, or the `~=` operator directly)
+/// to determine if a status tag belongs to one of the known categories:
+///
+/// ```swift
+/// if case .letter = cursor.ruleStatus {
+///   // do something
+/// }
+/// ```
+///
+/// **Terminology note:** The name "cursor" has been chosen instead of
+/// "iterator" to better map to the concepts found in Swift. Swift's iterator
+/// types provide unidirectional traversal of a sequence; by contrast, a
+/// "cursor" more accurately describes this type, which can move forward and
+/// backward arbitrarily within a string.
+public final class WordBreakCursor {
+
+  /// Represents the status tag from a break rule.
+  public struct RuleStatus {
+
+    /// The raw integer value of the status tag.
+    public let rawValue: Int
+
+    /// Creates a new `RuleStatus` value with the given integer value.
+    ///
+    /// - Parameter rawValue: The integer value of the status tag.
+    init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+  }
+
+  /// Represents a range of status tags from a break rule.
+  ///
+  /// The rule status tags for word breaks are meant to be treated as ranges,
+  /// not exact values; this allows future versions of the library to further
+  /// subdivide a break rule's tags. Thus, `RuleStatus` values should not be
+  /// compared using equality, but instead use the `~=` operator (directly, or
+  /// through pattern matching):
+  ///
+  /// ```swift
+  /// if case .letter = cursor.ruleStatus {
+  ///   // do something
+  /// }
+  /// ```
+  public struct RuleStatusRange {
+
+    /// The range of integer values.
+    private let range: Range<Int>
+
+    /// Creates a new rule status range from a range of unsigned integers.
+    ///
+    /// - Parameter range: The range of unsigned integers.
+    private init(_ range: Range<UInt32>) {
+      self.range = Int(range.lowerBound)..<Int(range.upperBound)
+    }
+
+    /// The rule status range containing "words" that do not fit into any of
+    /// the other categories (such as spaces and most punctuation).
+    public static let none = RuleStatusRange(
+      UBRK_WORD_NONE.rawValue..<UBRK_WORD_NONE_LIMIT.rawValue)
+
+    /// The rule status range containing "words" that appear to be numbers.
+    public static let number = RuleStatusRange(
+      UBRK_WORD_NUMBER.rawValue..<UBRK_WORD_NUMBER_LIMIT.rawValue)
+
+    /// The rule status range for words that contain letters (excluding
+    /// hiragana, katakana, and ideographic characters).
+    public static let letter = RuleStatusRange(
+      UBRK_WORD_LETTER.rawValue..<UBRK_WORD_LETTER_LIMIT.rawValue)
+
+    /// The rule status range for words containing hiragana or katakana.
+    public static let kana = RuleStatusRange(
+      UBRK_WORD_KANA.rawValue..<UBRK_WORD_KANA_LIMIT.rawValue)
+
+    /// The rule status range for words containing ideographic characters.
+    public static let ideographic = RuleStatusRange(
+      UBRK_WORD_IDEO.rawValue..<UBRK_WORD_IDEO_LIMIT.rawValue)
+
+    /// Returns true if the range contains the given rule status tag.
+    ///
+    /// - Parameters:
+    ///   - range: The rule status range.
+    ///   - ruleStatus: The rule status.
+    /// - Returns: True if the range contains the given rule status tag.
+    public static func ~= (
+      range: RuleStatusRange,
+      ruleStatus: RuleStatus
+    ) -> Bool {
+      return range.range.contains(ruleStatus.rawValue)
+    }
+  }
+
+  /// The status tag from the break rule that determined the most recently
+  /// returned break position.
+  ///
+  /// If more than one break rule applied at the current position, then the
+  /// numerically largest status tag is returned.
+  public var ruleStatus: RuleStatus {
+    return impl.ruleStatus
+  }
+
+  /// The status tags from the break rules that determined the most recently
+  /// returned break position.
+  public var ruleStatuses: [RuleStatus] {
+    return impl.ruleStatuses
+  }
+
+  /// The actual break cursor implementation to which this class's operations
+  /// are delegated.
+  private var impl: BreakCursorImpl<RuleStatus>
+
+  /// The text being scanned by the cursor.
+  public var text: String? {
+    get { return impl.text }
+    set { impl.text = newValue }
+  }
+
+  /// The most recently returned text boundary.
+  public var index: String.Index? {
+    return impl.index
+  }
+
+  /// The locale used to determine the language rules for text breaking.
+  public let locale: String?
+
+  /// Creates a new word break cursor with the given rules.
+  ///
+  /// - Parameters:
+  ///   - text: The optional initial text that the cursor will scan.
+  ///   - locale: The locale used to determine the language rules for text
+  ///     breaking.
+  public init(text: String? = nil, locale: String? = nil) {
+    self.locale = locale
+    self.impl = BreakCursorImpl(
+      type: UBRK_WORD,
+      text: text,
+      locale: locale,
+      ruleStatusFactory: RuleStatus.init)
+  }
+
+  deinit {
+    impl.release()
+  }
+
+  /// Returns the start index of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// text's starting index.
+  ///
+  /// - Returns: The start index of the text being scanned.
+  public func first() -> String.Index {
+    return impl.first()
+  }
+
+  /// Returns the index past the last character of the text being scanned.
+  ///
+  /// This method also adjusts the cursor such that its `index` is equal to the
+  /// index past the last character of the text.
+  ///
+  /// - Returns: The index past the last character of the text being scanned.
+  public func last() -> String.Index {
+    return impl.last()
+  }
+
+  /// Returns the index of the boundary following the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the next boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the next boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func next() -> String.Index? {
+    return impl.next()
+  }
+
+  /// Returns the index of the boundary preceding the current boundary in the
+  /// text.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// position of the previous boundary, or `nil` if all boundaries have been
+  /// returned.
+  ///
+  /// - Returns: The index of the previous boundary in the text, or nil if all
+  ///   boundaries have been returned.
+  public func previous() -> String.Index? {
+    return impl.previous()
+  }
+
+  /// Returns the first index greater than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// after `index`.
+  ///
+  /// - Parameter index: The index at which scanning should begin.
+  /// - Returns: The index of the first boundary following `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(following index: String.Index) -> String.Index? {
+    return impl.moveToIndex(following: index)
+  }
+
+  /// Returns the first index less than `index` at which a boundary occurs.
+  ///
+  /// This method adjusts the cursor such that its `index` is equal to the
+  /// boundary position if one was found, or `nil` if there were no boundaries
+  /// before `index`.
+  ///
+  /// - Parameter index: The index at which the scanning should begin.
+  /// - Returns: The index of the first boundary preceding `index`, or nil if no
+  ///   boundaries were found.
+  public func moveToIndex(preceding index: String.Index) -> String.Index? {
+    return impl.moveToIndex(preceding: index)
+  }
+
+  /// Returns true if the given index represents a boundary position in the
+  /// cursor's text, also moving the cursor to the first boundary at or
+  /// following that index.
+  ///
+  /// - Parameter index: The index to check.
+  /// - Returns: True if the given index is a boundary position.
+  public func isBoundary(movingToOrAfter index: String.Index) -> Bool {
+    return impl.isBoundary(movingToOrAfter: index)
+  }
+}

--- a/Tests/ICUTests/CharacterBreakCursorTests.swift
+++ b/Tests/ICUTests/CharacterBreakCursorTests.swift
@@ -1,0 +1,95 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU
+import XCTest
+
+/// Unit tests for `CharacterBreakCursor`.
+class CharacterBreakCursorTests: XCTestCase {
+  //                    01                                         23
+  let text =           "a\u{1F937}\u{1F3FD}\u{200D}\u{2642}\u{FE0F}b"
+
+  var cursor: CharacterBreakCursor!
+
+  override func setUp() {
+    cursor = CharacterBreakCursor(text: text)
+  }
+
+  func testBreaksForward() {
+    assertBreak(cursor.first(), at: 0)
+    assertBreak(cursor.next(), at: 1)
+    assertBreak(cursor.next(), at: 2)
+    assertBreak(cursor.next(), at: 3)
+    XCTAssertNil(cursor.next())
+  }
+
+  func testBreaksBackward() {
+    assertBreak(cursor.last(), at: 3)
+    assertBreak(cursor.previous(), at: 2)
+    assertBreak(cursor.previous(), at: 1)
+    assertBreak(cursor.previous(), at: 0)
+    XCTAssertNil(cursor.previous())
+  }
+
+  func testBreaksFollowing() {
+    assertBreak(cursor.moveToIndex(
+      following: text.index(text.startIndex, offsetBy: 2)), at: 3)
+    XCTAssertNil(cursor.moveToIndex(following: text.endIndex))
+  }
+
+  func testBreaksPreceding() {
+    assertBreak(cursor.moveToIndex(
+      preceding: text.index(text.startIndex, offsetBy: 3)), at: 2)
+    XCTAssertNil(cursor.moveToIndex(preceding: text.startIndex))
+  }
+
+  func testIsBoundary() {
+    XCTAssertTrue(cursor.isBoundary(movingToOrAfter: text.startIndex))
+    assertBreak(cursor.index, at: 0)
+
+    // This even works with String indices that are in the middle of a
+    // character, like the following example where the index is in the middle of
+    // a multi-scalar cluster that combine to make a single emoji character.
+    // Swift's indices, combined with ICU functionality, properly determine that
+    // the index is not a character boundary and moves it to the correct
+    // position.
+    let scalars = text.unicodeScalars
+    XCTAssertFalse(cursor.isBoundary(
+      movingToOrAfter: scalars.index(scalars.startIndex, offsetBy: 2)))
+    assertBreak(cursor.index, at: 2)
+  }
+
+  func testSetText() {
+    cursor.text = "abc"
+    _ = cursor.first()
+    assertBreak(cursor.next(), at: 1)
+  }
+
+  /// Asserts that the given break index is `distance` from the start of the
+  /// string and that the most recent rule status matches the given one.
+  private func assertBreak(
+    _ index: String.Index?,
+    at distance: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    assertIndex(
+      index,
+      isDistance: distance,
+      fromStartOf: text,
+      file: file,
+      line: line)
+  }
+}
+

--- a/Tests/ICUTests/LineBreakCursorTests.swift
+++ b/Tests/ICUTests/LineBreakCursorTests.swift
@@ -1,0 +1,102 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU
+import XCTest
+
+/// Unit tests for `LineBreakCursor`.
+class LineBreakCursorTests: XCTestCase {
+  //                    000000000011 11111111222222222
+  //                    012345678901 23456789012345678
+  let text =           "Here's some\npossible—breaks."
+  //                    0      0     1       00      0
+  // 0 = .soft
+  // 1 = .hard
+  
+  var cursor: LineBreakCursor!
+  
+  override func setUp() {
+    cursor = LineBreakCursor(text: text)
+  }
+  
+  func testBreaksForward() {
+    assertBreak(cursor.first(), at: 0, status: .soft)
+    assertBreak(cursor.next(), at: 7, status: .soft)
+    assertBreak(cursor.next(), at: 12, status: .hard)
+    assertBreak(cursor.next(), at: 20, status: .soft)
+    assertBreak(cursor.next(), at: 21, status: .soft)
+    assertBreak(cursor.next(), at: 28, status: .soft)
+    XCTAssertNil(cursor.next())
+  }
+  
+  func testBreaksBackward() {
+    assertBreak(cursor.last(), at: 28, status: .soft)
+    assertBreak(cursor.previous(), at: 21, status: .soft)
+    assertBreak(cursor.previous(), at: 20, status: .soft)
+    assertBreak(cursor.previous(), at: 12, status: .hard)
+    assertBreak(cursor.previous(), at: 7, status: .soft)
+    assertBreak(cursor.previous(), at: 0, status: .soft)
+    XCTAssertNil(cursor.previous())
+  }
+  
+  func testBreaksFollowing() {
+    assertBreak(cursor.moveToIndex(
+      following: text.index(text.startIndex, offsetBy: 15)
+    ), at: 20, status: .soft)
+    XCTAssertNil(cursor.moveToIndex(following: text.endIndex))
+  }
+  
+  func testBreaksPreceding() {
+    assertBreak(cursor.moveToIndex(
+      preceding: text.index(text.startIndex, offsetBy: 18)
+    ), at: 12, status: .hard)
+    XCTAssertNil(cursor.moveToIndex(preceding: text.startIndex))
+  }
+
+  func testIsBoundary() {
+    XCTAssertTrue(cursor.isBoundary(
+      movingToOrAfter: text.index(text.startIndex, offsetBy: 12)))
+    assertBreak(cursor.index, at: 12, status: .hard)
+
+    XCTAssertFalse(cursor.isBoundary(
+      movingToOrAfter: text.index(text.startIndex, offsetBy: 17)))
+    assertBreak(cursor.index, at: 20, status: .soft)
+  }
+
+  func testSetText() {
+    cursor.text = "a\nb"
+    _ = cursor.first()
+    assertBreak(cursor.next(), at: 2, status: .hard)
+  }
+
+  /// Asserts that the given break index is `distance` from the start of the
+  /// string and that the most recent rule status matches the given one.
+  private func assertBreak(
+    _ index: String.Index?,
+    at distance: Int,
+    status: LineBreakCursor.RuleStatusRange,
+    file: StaticString = #file,
+    line: UInt = #line
+    ) {
+    assertIndex(
+      index,
+      isDistance: distance,
+      fromStartOf: text,
+      file: file,
+      line: line)
+    XCTAssertTrue(status ~= cursor.ruleStatus, file: file, line: line)
+  }
+}
+
+

--- a/Tests/ICUTests/RuleBasedBreakCursorTests.swift
+++ b/Tests/ICUTests/RuleBasedBreakCursorTests.swift
@@ -1,0 +1,76 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU
+import XCTest
+
+/// Unit tests for `RuleBasedBreakCursor`.
+class RuleBasedBreakCursorTests: XCTestCase {
+
+  let text = "AB12"
+  var cursor: RuleBasedBreakCursor<Int>!
+  
+  override func setUp() {
+    do {
+      let breakRules = """
+        [A-Z]{100};
+        [\\p{Lu}]{200};
+        [0-9]{300};
+        [\\p{N}]{400};
+        !.*;
+        """
+      cursor = try RuleBasedBreakCursor(rules: breakRules, text: text)
+    } catch {
+      XCTFail("Setup should not throw error")
+    }
+  }
+  
+  func testInvalidRule() {
+    let badRules = """
+                 # This is a rule comment on line 1
+      [:L:];     # This rule is OK.
+      abcdefg);  # Error, mismatched parens
+      """
+    XCTAssertThrowsError(try RuleBasedBreakCursor(rules: badRules)) { error in
+      guard case BreakRuleParseError.mismatchedParentheses(
+        let context) = error
+      else {
+        XCTFail("Expected mismatchedParentheses thrown, but got \(error)")
+        return
+      }
+      guard case ParseErrorContext.Location.lineAndColumn(
+        line: let line, column: let column) = context.location
+      else {
+        XCTFail("Expected lineAndColumn location, but got \(context.location)")
+        return
+      }
+      XCTAssertEqual(line, 3)
+      XCTAssertEqual(column, 8)
+    }
+  }
+
+  func testRuleStatuses() {
+    assertIndex(cursor.first(), isDistance: 0, fromStartOf: text)
+    XCTAssertEqual(cursor.ruleStatuses, [0])
+    assertIndex(cursor.next(), isDistance: 1, fromStartOf: text)
+    XCTAssertEqual(cursor.ruleStatuses, [100, 200])
+    assertIndex(cursor.next(), isDistance: 2, fromStartOf: text)
+    XCTAssertEqual(cursor.ruleStatuses, [100, 200])
+    assertIndex(cursor.next(), isDistance: 3, fromStartOf: text)
+    XCTAssertEqual(cursor.ruleStatuses, [300, 400])
+    assertIndex(cursor.next(), isDistance: 4, fromStartOf: text)
+    XCTAssertEqual(cursor.ruleStatuses, [300, 400])
+    XCTAssertNil(cursor.next())
+  }
+}

--- a/Tests/ICUTests/SentenceBreakCursorTests.swift
+++ b/Tests/ICUTests/SentenceBreakCursorTests.swift
@@ -1,0 +1,97 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU
+import XCTest
+
+/// Unit tests for `SentenceBreakCursor`.
+class SentenceBreakCursorTests: XCTestCase {
+  //                    0000000000111111111122222222223 33333333344444
+  //                    0123456789012345678901234567890 12345678901234
+  let text =           "Here's a sentence. Another one\nAnd one more?"
+  //                    0                  0            1            0
+  // 0 = .terminator
+  // 1 = .separator
+  
+  var cursor: SentenceBreakCursor!
+  
+  override func setUp() {
+    cursor = SentenceBreakCursor(text: text)
+  }
+  
+  func testBreaksForward() {
+    assertBreak(cursor.first(), at: 0, status: .terminator)
+    assertBreak(cursor.next(), at: 19, status: .terminator)
+    assertBreak(cursor.next(), at: 31, status: .separator)
+    assertBreak(cursor.next(), at: 44, status: .terminator)
+    XCTAssertNil(cursor.next())
+  }
+  
+  func testBreaksBackward() {
+    assertBreak(cursor.last(), at: 44, status: .terminator)
+    assertBreak(cursor.previous(), at: 31, status: .separator)
+    assertBreak(cursor.previous(), at: 19, status: .terminator)
+    assertBreak(cursor.previous(), at: 0, status: .terminator)
+    XCTAssertNil(cursor.previous())
+  }
+  
+  func testBreaksFollowing() {
+    assertBreak(cursor.moveToIndex(
+      following: text.index(text.startIndex, offsetBy: 15)
+    ), at: 19, status: .terminator)
+    XCTAssertNil(cursor.moveToIndex(following: text.endIndex))
+  }
+  
+  func testBreaksPreceding() {
+    assertBreak(cursor.moveToIndex(
+      preceding: text.index(text.startIndex, offsetBy: 35)
+    ), at: 31, status: .separator)
+    XCTAssertNil(cursor.moveToIndex(preceding: text.startIndex))
+  }
+
+  func testIsBoundary() {
+    XCTAssertTrue(cursor.isBoundary(
+      movingToOrAfter: text.index(text.startIndex, offsetBy: 19)))
+    assertBreak(cursor.index, at: 19, status: .terminator)
+
+    XCTAssertFalse(cursor.isBoundary(
+      movingToOrAfter: text.index(text.startIndex, offsetBy: 28)))
+    assertBreak(cursor.index, at: 31, status: .separator)
+  }
+
+  func testSetText() {
+    cursor.text = "A. B."
+    _ = cursor.first()
+    assertBreak(cursor.next(), at: 3, status: .terminator)
+  }
+
+  /// Asserts that the given break index is `distance` from the start of the
+  /// string and that the most recent rule status matches the given one.
+  private func assertBreak(
+    _ index: String.Index?,
+    at distance: Int,
+    status: SentenceBreakCursor.RuleStatusRange,
+    file: StaticString = #file,
+    line: UInt = #line
+    ) {
+    assertIndex(
+      index,
+      isDistance: distance,
+      fromStartOf: text,
+      file: file,
+      line: line)
+    XCTAssertTrue(status ~= cursor.ruleStatus, file: file, line: line)
+  }
+}
+

--- a/Tests/ICUTests/WordBreakCursorTests.swift
+++ b/Tests/ICUTests/WordBreakCursorTests.swift
@@ -1,0 +1,116 @@
+// Copyright 2017 Tony Allevato.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ICU
+import XCTest
+
+/// Unit tests for `WordBreakCursor`.
+class WordBreakCursorTests: XCTestCase {
+  //                    000000000011111111112222222
+  //                    012345678901234567890123456
+  let text =           "This is the test, isn't it?"
+  //                    0   10 10  10   100    10 10
+  // 0 = .none
+  // 1 = .letter
+
+  var cursor: WordBreakCursor!
+
+  override func setUp() {
+    cursor = WordBreakCursor(text: text)
+  }
+
+  func testBreaksForward() {
+    assertBreak(cursor.first(), at: 0, status: .none)
+    assertBreak(cursor.next(), at: 4, status: .letter)
+    assertBreak(cursor.next(), at: 5, status: .none)
+    assertBreak(cursor.next(), at: 7, status: .letter)
+    assertBreak(cursor.next(), at: 8, status: .none)
+    assertBreak(cursor.next(), at: 11, status: .letter)
+    assertBreak(cursor.next(), at: 12, status: .none)
+    assertBreak(cursor.next(), at: 16, status: .letter)
+    assertBreak(cursor.next(), at: 17, status: .none)
+    assertBreak(cursor.next(), at: 18, status: .none)
+    assertBreak(cursor.next(), at: 23, status: .letter)
+    assertBreak(cursor.next(), at: 24, status: .none)
+    assertBreak(cursor.next(), at: 26, status: .letter)
+    assertBreak(cursor.next(), at: 27, status: .none)
+    XCTAssertNil(cursor.next())
+  }
+
+  func testBreaksBackward() {
+    assertBreak(cursor.last(), at: 27, status: .none)
+    assertBreak(cursor.previous(), at: 26, status: .letter)
+    assertBreak(cursor.previous(), at: 24, status: .none)
+    assertBreak(cursor.previous(), at: 23, status: .letter)
+    assertBreak(cursor.previous(), at: 18, status: .none)
+    assertBreak(cursor.previous(), at: 17, status: .none)
+    assertBreak(cursor.previous(), at: 16, status: .letter)
+    assertBreak(cursor.previous(), at: 12, status: .none)
+    assertBreak(cursor.previous(), at: 11, status: .letter)
+    assertBreak(cursor.previous(), at: 8, status: .none)
+    assertBreak(cursor.previous(), at: 7, status: .letter)
+    assertBreak(cursor.previous(), at: 5, status: .none)
+    assertBreak(cursor.previous(), at: 4, status: .letter)
+    assertBreak(cursor.previous(), at: 0, status: .none)
+    XCTAssertNil(cursor.previous())
+  }
+  
+  func testBreaksFollowing() {
+    assertBreak(cursor.moveToIndex(
+      following: text.index(text.startIndex, offsetBy: 2)
+    ), at: 4, status: .letter)
+    XCTAssertNil(cursor.moveToIndex(following: text.endIndex))
+  }
+
+  func testBreaksPreceding() {
+    assertBreak(cursor.moveToIndex(
+      preceding: text.index(text.startIndex, offsetBy: 20)
+    ), at: 18, status: .none)
+    XCTAssertNil(cursor.moveToIndex(preceding: text.startIndex))
+  }
+
+  func testIsBoundary() {
+    XCTAssertTrue(cursor.isBoundary(
+      movingToOrAfter: text.index(text.startIndex, offsetBy: 12)))
+    assertBreak(cursor.index, at: 12, status: .none)
+
+    XCTAssertFalse(cursor.isBoundary(
+      movingToOrAfter: text.index(text.startIndex, offsetBy: 14)))
+    assertBreak(cursor.index, at: 16, status: .letter)
+  }
+
+  func testSetText() {
+    cursor.text = "one two"
+    _ = cursor.first()
+    assertBreak(cursor.next(), at: 3, status: .letter)
+  }
+
+  /// Asserts that the given break index is `distance` from the start of the
+  /// string and that the most recent rule status matches the given one.
+  private func assertBreak(
+    _ index: String.Index?,
+    at distance: Int,
+    status: WordBreakCursor.RuleStatusRange,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    assertIndex(
+      index,
+      isDistance: distance,
+      fromStartOf: text,
+      file: file,
+      line: line)
+    XCTAssertTrue(status ~= cursor.ruleStatus, file: file, line: line)
+  }
+}


### PR DESCRIPTION
This change adds a number of new types to represent ICU's various break iterators (which we call "cursors"). Rather than having a single type that represents all `ubrk_*` functionality, there is a concrete type for each kind of cursor (`Character`, `Line`, `RuleBased`, `Sentence`, and `Word`), which allows us to use strongly typed rule status values instead of plain integers.

Fixes #3.